### PR TITLE
Add span name providing functionality. (#1)

### DIFF
--- a/opentracing-kafka-client/src/main/java/io/opentracing/contrib/kafka/ClientSpanNameProvider.java
+++ b/opentracing-kafka-client/src/main/java/io/opentracing/contrib/kafka/ClientSpanNameProvider.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2017-2018 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.opentracing.contrib.kafka;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.producer.ProducerRecord;
+
+import java.util.function.BiFunction;
+
+/**
+ * @author Jordan J Lopez
+ *  Returns a string to be used as the name of the spans, based on
+ *  the operation preformed and the record the span is based off of.
+ */
+public class ClientSpanNameProvider {
+
+  // Operation Name as Span Name
+  public static BiFunction<String, ConsumerRecord, String> CONSUMER_OPERATION_NAME =
+      (operationName, consumerRecord) -> replaceIfNull(operationName, "unknown");
+  public static BiFunction<String, ProducerRecord, String> PRODUCER_OPERATION_NAME =
+      (operationName, producerRecord) -> replaceIfNull(operationName, "unknown");
+
+  public static BiFunction<String, ConsumerRecord, String> CONSUMER_PREFIXED_OPERATION_NAME(final String prefix) {
+    return (operationName, consumerRecord) -> replaceIfNull(prefix, "")
+        + replaceIfNull(operationName, "unknown");
+  }
+  public static BiFunction<String, ProducerRecord, String> PRODUCER_PREFIXED_OPERATION_NAME(final String prefix) {
+    return (operationName, producerRecord) -> replaceIfNull(prefix, "")
+        + replaceIfNull(operationName, "unknown");
+  }
+
+  // Topic as Span Name
+  public static BiFunction<String, ConsumerRecord, String> CONSUMER_TOPIC =
+      (operationName, consumerRecord) -> replaceIfNull(consumerRecord, "unknown");
+  public static BiFunction<String, ProducerRecord, String> PRODUCER_TOPIC =
+      (operationName, producerRecord) -> replaceIfNull(producerRecord, "unknown");
+
+  public static BiFunction<String, ConsumerRecord, String> CONSUMER_PREFIXED_TOPIC(final String prefix) {
+    return (operationName, consumerRecord) -> replaceIfNull(prefix, "")
+        + replaceIfNull(consumerRecord, "unknown");
+  }
+  public static BiFunction<String, ProducerRecord, String> PRODUCER_PREFIXED_TOPIC(final String prefix) {
+    return (operationName, producerRecord) -> replaceIfNull(prefix, "")
+        + replaceIfNull(producerRecord, "unknown");
+  }
+
+  // Operation Name and Topic as Span Name
+  public static BiFunction<String, ConsumerRecord, String> CONSUMER_OPERATION_NAME_TOPIC =
+      (operationName, consumerRecord) -> replaceIfNull(operationName, "unknown")
+      + " - " + replaceIfNull(consumerRecord, "unknown");
+  public static BiFunction<String, ProducerRecord, String> PRODUCER_OPERATION_NAME_TOPIC =
+      (operationName, producerRecord) -> replaceIfNull(operationName, "unknown")
+      + " - " + replaceIfNull(producerRecord, "unknown");
+
+  public static BiFunction<String, ConsumerRecord, String> CONSUMER_PREFIXED_OPERATION_NAME_TOPIC(final String prefix) {
+    return (operationName, consumerRecord) -> replaceIfNull(prefix, "")
+        + replaceIfNull(operationName, "unknown")
+        + " - " + replaceIfNull(consumerRecord, "unknown");
+  }
+  public static BiFunction<String, ProducerRecord, String> PRODUCER_PREFIXED_OPERATION_NAME_TOPIC(final String prefix) {
+    return (operationName, producerRecord) -> replaceIfNull(prefix, "")
+        + replaceIfNull(operationName, "unknown")
+        + " - " + replaceIfNull(producerRecord, "unknown");
+  }
+
+  private static String replaceIfNull(String input, String replacement) {
+    return (input == null) ? replacement : input;
+  }
+
+  private static String replaceIfNull(ConsumerRecord input, String replacement) {
+    return ((input == null) ? replacement : input.topic());
+  }
+
+  private static String replaceIfNull(ProducerRecord input, String replacement) {
+    return ((input == null) ? replacement : input.topic());
+  }
+
+}

--- a/opentracing-kafka-client/src/test/java/io/opentracing/contrib/kafka/OperationNameSpanNameTest.java
+++ b/opentracing-kafka-client/src/test/java/io/opentracing/contrib/kafka/OperationNameSpanNameTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2017-2018 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.opentracing.contrib.kafka;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.junit.Test;
+
+import java.util.function.BiFunction;
+
+import static org.junit.Assert.assertEquals;
+
+public class OperationNameSpanNameTest {
+  private final ConsumerRecord<String, Integer> consumerRecord = new ConsumerRecord("example_topic", 0, 0, "KEY", 999);
+  private final ProducerRecord<String, Integer> producerRecord = new ProducerRecord("example_topic", 0, System.currentTimeMillis(), "KEY", 999);
+  private BiFunction<String, ConsumerRecord, String> consumerSpanNameProvider;
+  private BiFunction<String, ProducerRecord, String> producerSpanNameProvider;
+
+  @Test
+  public void operationNameSpanNameTest() {
+    consumerSpanNameProvider = ClientSpanNameProvider.CONSUMER_OPERATION_NAME;
+    producerSpanNameProvider = ClientSpanNameProvider.PRODUCER_OPERATION_NAME;
+
+    assertEquals("receive", consumerSpanNameProvider.apply("receive", consumerRecord));
+    assertEquals("send", producerSpanNameProvider.apply("send", producerRecord));
+
+    assertEquals("unknown", consumerSpanNameProvider.apply(null, consumerRecord));
+    assertEquals("unknown", producerSpanNameProvider.apply(null, producerRecord));
+
+    assertEquals("receive", consumerSpanNameProvider.apply("receive", null));
+    assertEquals("send", producerSpanNameProvider.apply("send", null));
+
+    assertEquals("unknown", consumerSpanNameProvider.apply(null, null));
+    assertEquals("unknown", producerSpanNameProvider.apply(null, null));
+  }
+
+  @Test
+  public void prefixedOperationNameSpanNameTest() {
+    consumerSpanNameProvider = ClientSpanNameProvider.CONSUMER_PREFIXED_OPERATION_NAME("KafkaClient: ");
+    producerSpanNameProvider = ClientSpanNameProvider.PRODUCER_PREFIXED_OPERATION_NAME("KafkaClient: ");
+
+    assertEquals("KafkaClient: receive", consumerSpanNameProvider.apply("receive", consumerRecord));
+    assertEquals("KafkaClient: send", producerSpanNameProvider.apply("send", producerRecord));
+
+    assertEquals("KafkaClient: unknown", consumerSpanNameProvider.apply(null, consumerRecord));
+    assertEquals("KafkaClient: unknown", producerSpanNameProvider.apply(null, producerRecord));
+
+    assertEquals("KafkaClient: receive", consumerSpanNameProvider.apply("receive", null));
+    assertEquals("KafkaClient: send", producerSpanNameProvider.apply("send", null));
+
+    assertEquals("KafkaClient: unknown", consumerSpanNameProvider.apply(null, null));
+    assertEquals("KafkaClient: unknown", producerSpanNameProvider.apply(null, null));
+
+    consumerSpanNameProvider = ClientSpanNameProvider.CONSUMER_PREFIXED_OPERATION_NAME(null);
+    producerSpanNameProvider = ClientSpanNameProvider.PRODUCER_PREFIXED_OPERATION_NAME(null);
+
+    assertEquals("receive", consumerSpanNameProvider.apply("receive", consumerRecord));
+    assertEquals("send", producerSpanNameProvider.apply("send", producerRecord));
+
+    assertEquals("unknown", consumerSpanNameProvider.apply(null, consumerRecord));
+    assertEquals("unknown", producerSpanNameProvider.apply(null, producerRecord));
+
+    assertEquals("receive", consumerSpanNameProvider.apply("receive", null));
+    assertEquals("send", producerSpanNameProvider.apply("send", null));
+
+    assertEquals("unknown", consumerSpanNameProvider.apply(null, null));
+    assertEquals("unknown", producerSpanNameProvider.apply(null, null));
+  }
+}

--- a/opentracing-kafka-client/src/test/java/io/opentracing/contrib/kafka/OperationNameTopicSpanNameTest.java
+++ b/opentracing-kafka-client/src/test/java/io/opentracing/contrib/kafka/OperationNameTopicSpanNameTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2017-2018 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.opentracing.contrib.kafka;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.junit.Test;
+
+import java.util.function.BiFunction;
+
+import static org.junit.Assert.assertEquals;
+
+public class OperationNameTopicSpanNameTest {
+  private final ConsumerRecord<String, Integer> consumerRecord = new ConsumerRecord("example_topic", 0, 0, "KEY", 999);
+  private final ProducerRecord<String, Integer> producerRecord = new ProducerRecord("example_topic", 0, System.currentTimeMillis(), "KEY", 999);
+  private BiFunction<String, ConsumerRecord, String> consumerSpanNameProvider;
+  private BiFunction<String, ProducerRecord, String> producerSpanNameProvider;
+
+  @Test
+  public void operationNameTopicSpanNameTest() {
+    consumerSpanNameProvider = ClientSpanNameProvider.CONSUMER_OPERATION_NAME_TOPIC;
+    producerSpanNameProvider = ClientSpanNameProvider.PRODUCER_OPERATION_NAME_TOPIC;
+
+    assertEquals("receive - example_topic", consumerSpanNameProvider.apply("receive", consumerRecord));
+    assertEquals("send - example_topic", producerSpanNameProvider.apply("send", producerRecord));
+
+    assertEquals("unknown - example_topic", consumerSpanNameProvider.apply(null, consumerRecord));
+    assertEquals("unknown - example_topic", producerSpanNameProvider.apply(null, producerRecord));
+
+    assertEquals("receive - unknown", consumerSpanNameProvider.apply("receive", null));
+    assertEquals("send - unknown", producerSpanNameProvider.apply("send", null));
+
+    assertEquals("unknown - unknown", consumerSpanNameProvider.apply(null, null));
+    assertEquals("unknown - unknown", producerSpanNameProvider.apply(null, null));
+  }
+
+  @Test
+  public void prefixedOperationNameTopicSpanNameTest() {
+    consumerSpanNameProvider = ClientSpanNameProvider.CONSUMER_PREFIXED_OPERATION_NAME_TOPIC("KafkaClient: ");
+    producerSpanNameProvider = ClientSpanNameProvider.PRODUCER_PREFIXED_OPERATION_NAME_TOPIC("KafkaClient: ");
+
+    assertEquals("KafkaClient: receive - example_topic", consumerSpanNameProvider.apply("receive", consumerRecord));
+    assertEquals("KafkaClient: send - example_topic", producerSpanNameProvider.apply("send", producerRecord));
+
+    assertEquals("KafkaClient: unknown - example_topic", consumerSpanNameProvider.apply(null, consumerRecord));
+    assertEquals("KafkaClient: unknown - example_topic", producerSpanNameProvider.apply(null, producerRecord));
+
+    assertEquals("KafkaClient: receive - unknown", consumerSpanNameProvider.apply("receive", null));
+    assertEquals("KafkaClient: send - unknown", producerSpanNameProvider.apply("send", null));
+
+    assertEquals("KafkaClient: unknown - unknown", consumerSpanNameProvider.apply(null, null));
+    assertEquals("KafkaClient: unknown - unknown", producerSpanNameProvider.apply(null, null));
+
+    consumerSpanNameProvider = ClientSpanNameProvider.CONSUMER_PREFIXED_OPERATION_NAME_TOPIC(null);
+    producerSpanNameProvider = ClientSpanNameProvider.PRODUCER_PREFIXED_OPERATION_NAME_TOPIC(null);
+
+    assertEquals("receive - example_topic", consumerSpanNameProvider.apply("receive", consumerRecord));
+    assertEquals("send - example_topic", producerSpanNameProvider.apply("send", producerRecord));
+
+    assertEquals("unknown - example_topic", consumerSpanNameProvider.apply(null, consumerRecord));
+    assertEquals("unknown - example_topic", producerSpanNameProvider.apply(null, producerRecord));
+
+    assertEquals("receive - unknown", consumerSpanNameProvider.apply("receive", null));
+    assertEquals("send - unknown", producerSpanNameProvider.apply("send", null));
+
+    assertEquals("unknown - unknown", consumerSpanNameProvider.apply(null, null));
+    assertEquals("unknown - unknown", producerSpanNameProvider.apply(null, null));
+  }
+}

--- a/opentracing-kafka-client/src/test/java/io/opentracing/contrib/kafka/TopicSpanNameTest.java
+++ b/opentracing-kafka-client/src/test/java/io/opentracing/contrib/kafka/TopicSpanNameTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2017-2018 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.opentracing.contrib.kafka;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.junit.Test;
+
+import java.util.function.BiFunction;
+
+import static org.junit.Assert.assertEquals;
+
+public class TopicSpanNameTest {
+
+  private final ConsumerRecord<String, Integer> consumerRecord = new ConsumerRecord("example_topic", 0, 0, "KEY", 999);
+  private final ProducerRecord<String, Integer> producerRecord = new ProducerRecord("example_topic", 0, System.currentTimeMillis(), "KEY", 999);
+  private BiFunction<String, ConsumerRecord, String> consumerSpanNameProvider;
+  private BiFunction<String, ProducerRecord, String> producerSpanNameProvider;
+
+  @Test
+  public void topicSpanNameTest() {
+
+    consumerSpanNameProvider = ClientSpanNameProvider.CONSUMER_TOPIC;
+    producerSpanNameProvider = ClientSpanNameProvider.PRODUCER_TOPIC;
+
+    assertEquals("example_topic", consumerSpanNameProvider.apply("receive", consumerRecord));
+    assertEquals("example_topic", producerSpanNameProvider.apply("send", producerRecord));
+
+    assertEquals("example_topic", consumerSpanNameProvider.apply(null, consumerRecord));
+    assertEquals("example_topic", producerSpanNameProvider.apply(null, producerRecord));
+
+    assertEquals("unknown", consumerSpanNameProvider.apply("receive", null));
+    assertEquals("unknown", producerSpanNameProvider.apply("send", null));
+  }
+
+  @Test
+  public void prefixedTopicSpanNameTest() {
+    consumerSpanNameProvider = ClientSpanNameProvider.CONSUMER_PREFIXED_TOPIC("KafkaClient: ");
+    producerSpanNameProvider = ClientSpanNameProvider.PRODUCER_PREFIXED_TOPIC("KafkaClient: ");
+
+    assertEquals("KafkaClient: example_topic", consumerSpanNameProvider.apply("receive", consumerRecord));
+    assertEquals("KafkaClient: example_topic", producerSpanNameProvider.apply("send", producerRecord));
+
+    assertEquals("KafkaClient: example_topic", consumerSpanNameProvider.apply(null, consumerRecord));
+    assertEquals("KafkaClient: example_topic", producerSpanNameProvider.apply(null, producerRecord));
+
+    assertEquals("KafkaClient: unknown", consumerSpanNameProvider.apply("receive", null));
+    assertEquals("KafkaClient: unknown", producerSpanNameProvider.apply("send", null));
+
+    consumerSpanNameProvider = ClientSpanNameProvider.CONSUMER_PREFIXED_TOPIC(null);
+    producerSpanNameProvider = ClientSpanNameProvider.PRODUCER_PREFIXED_TOPIC(null);
+
+    assertEquals("example_topic", consumerSpanNameProvider.apply("receive", consumerRecord));
+    assertEquals("example_topic", producerSpanNameProvider.apply("send", producerRecord));
+
+    assertEquals("example_topic", consumerSpanNameProvider.apply(null, consumerRecord));
+    assertEquals("example_topic", producerSpanNameProvider.apply(null, producerRecord));
+
+    assertEquals("unknown", consumerSpanNameProvider.apply("receive", null));
+    assertEquals("unknown", producerSpanNameProvider.apply("send", null));
+  }
+}

--- a/opentracing-kafka-streams/src/main/java/io/opentracing/contrib/kafka/streams/TracingKafkaClientSupplier.java
+++ b/opentracing-kafka-streams/src/main/java/io/opentracing/contrib/kafka/streams/TracingKafkaClientSupplier.java
@@ -14,15 +14,19 @@
 package io.opentracing.contrib.kafka.streams;
 
 import io.opentracing.Tracer;
+import io.opentracing.contrib.kafka.ClientSpanNameProvider;
 import io.opentracing.contrib.kafka.TracingKafkaConsumer;
 import io.opentracing.contrib.kafka.TracingKafkaProducer;
 import java.util.Map;
+import java.util.function.BiFunction;
 
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.serialization.ByteArrayDeserializer;
 import org.apache.kafka.common.serialization.ByteArraySerializer;
 import org.apache.kafka.streams.KafkaClientSupplier;
@@ -30,9 +34,25 @@ import org.apache.kafka.streams.KafkaClientSupplier;
 public class TracingKafkaClientSupplier implements KafkaClientSupplier {
 
   private final Tracer tracer;
+  private final BiFunction<String, ConsumerRecord, String> consumerSpanNameProvider;
+  private final BiFunction<String, ProducerRecord, String> producerSpanNameProvider;
 
   public TracingKafkaClientSupplier(Tracer tracer) {
     this.tracer = tracer;
+    this.consumerSpanNameProvider = ClientSpanNameProvider.CONSUMER_OPERATION_NAME;
+    this.producerSpanNameProvider = ClientSpanNameProvider.PRODUCER_OPERATION_NAME;
+  }
+
+  public TracingKafkaClientSupplier(Tracer tracer,
+                                    BiFunction<String, ConsumerRecord, String> consumerSpanNameProvider,
+                                    BiFunction<String, ProducerRecord, String> producerSpanNameProvider) {
+    this.tracer = tracer;
+    this.consumerSpanNameProvider = (consumerSpanNameProvider == null)
+            ? ClientSpanNameProvider.CONSUMER_OPERATION_NAME
+            : consumerSpanNameProvider;
+    this.producerSpanNameProvider = (producerSpanNameProvider == null)
+            ? ClientSpanNameProvider.PRODUCER_OPERATION_NAME
+            : producerSpanNameProvider;
   }
 
   // This method is required by Kafka Streams >=1.1, and optional for Kafka Streams <1.1
@@ -44,20 +64,21 @@ public class TracingKafkaClientSupplier implements KafkaClientSupplier {
   @Override
   public Producer<byte[], byte[]> getProducer(Map<String, Object> config) {
     return new TracingKafkaProducer<>(
-        new KafkaProducer<>(config, new ByteArraySerializer(), new ByteArraySerializer()), tracer);
+        new KafkaProducer<>(config, new ByteArraySerializer(), new ByteArraySerializer()),
+            tracer, producerSpanNameProvider);
   }
 
   @Override
   public Consumer<byte[], byte[]> getConsumer(Map<String, Object> config) {
     return new TracingKafkaConsumer<>(
         new KafkaConsumer<>(config, new ByteArrayDeserializer(), new ByteArrayDeserializer()),
-        tracer);
+        tracer, consumerSpanNameProvider);
   }
 
   @Override
   public Consumer<byte[], byte[]> getRestoreConsumer(Map<String, Object> config) {
     return new TracingKafkaConsumer<>(
         new KafkaConsumer<>(config, new ByteArrayDeserializer(), new ByteArrayDeserializer()),
-        tracer);
+        tracer, consumerSpanNameProvider);
   }
 }


### PR DESCRIPTION
This PR adds the ability for users to create their own names for spans by providing BiFunctions to the traced consumers and producers in the driver.

Backwards compatibility is maintained, as it defaults to a span name provider BiFunction that mimics the current behavior.