### PR TITLE
Added VSCode specific items to Ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,9 @@
 .idea/
 *.iml
 target/
+.project
+.classpath
+.settings/**/*.*
+opentracing-kafka-client/.settings/**/*.*
+opentracing-kafka-spring/.settings/**/*.*
+opentracing-kafka-streams/.settings/**/*.*


### PR DESCRIPTION
This PR essentially modified the .gitignore file to include specific extensions creates by VSCode (Microsoft Visual Studio Code). By using this PR, this will allow developers that use VSCode to contribute to the project.