### PR TITLE
Fix typo in the README.md Kafka Streams example

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ SpanContext spanContext = TracingKafkaUtils.extractSpanContext(record.headers(),
 ```java
 
 // Instantiate TracingKafkaClientSupplier
-KafkaClientSupplier supplier = TracingKafkaClientSupplier(tracer);
+KafkaClientSupplier supplier = new TracingKafkaClientSupplier(tracer);
 
 // Provide supplier to KafkaStreams
 KafkaStreams streams = new KafkaStreams(builder.build(), new StreamsConfig(config), supplier);


### PR DESCRIPTION
The Kafka Streams example in the README.md seems to be missing the `new` and does not work.