### PR TITLE
Set scope=provided

### DIFF
--- a/opentracing-kafka-client/pom.xml
+++ b/opentracing-kafka-client/pom.xml
@@ -30,6 +30,7 @@
     <dependency>
       <groupId>org.apache.kafka</groupId>
       <artifactId>kafka-clients</artifactId>
+      <scope>provided</scope>
     </dependency>
   </dependencies>
 

--- a/opentracing-kafka-spring/pom.xml
+++ b/opentracing-kafka-spring/pom.xml
@@ -31,6 +31,7 @@
       <groupId>org.springframework.kafka</groupId>
       <artifactId>spring-kafka</artifactId>
       <version>${spring.kafka.version}</version>
+      <scope>provided</scope>
     </dependency>
 
     <dependency>

--- a/opentracing-kafka-streams/pom.xml
+++ b/opentracing-kafka-streams/pom.xml
@@ -30,6 +30,7 @@
     <dependency>
       <groupId>org.apache.kafka</groupId>
       <artifactId>kafka-streams</artifactId>
+      <scope>provided</scope>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Setting the scope of the target libraries of instrumentation to "provided". It is a guarantee that the integrating codebase will provide these libraries, otherwise the instrumentation plugin would be moot if the codebase does not already have these libraries.