### PR TITLE
Add public support for SpanDecorators in `buildAndFinishChildSpan` and `buildAndInjectSpan`

### DIFF
--- a/opentracing-kafka-client/src/main/java/io/opentracing/contrib/kafka/TracingKafkaUtils.java
+++ b/opentracing-kafka-client/src/main/java/io/opentracing/contrib/kafka/TracingKafkaUtils.java
@@ -68,7 +68,7 @@ public class TracingKafkaUtils {
         Collections.singletonList(SpanDecorator.STANDARD_TAGS));
   }
 
-  static <K, V> Span buildAndInjectSpan(ProducerRecord<K, V> record, Tracer tracer,
+  public static <K, V> Span buildAndInjectSpan(ProducerRecord<K, V> record, Tracer tracer,
       BiFunction<String, ProducerRecord, String> producerSpanNameProvider,
       SpanContext parent, Collection<SpanDecorator> spanDecorators) {
     String producerOper =
@@ -112,7 +112,7 @@ public class TracingKafkaUtils {
         Collections.singletonList(SpanDecorator.STANDARD_TAGS));
   }
 
-  static <K, V> void buildAndFinishChildSpan(ConsumerRecord<K, V> record, Tracer tracer,
+  public static <K, V> void buildAndFinishChildSpan(ConsumerRecord<K, V> record, Tracer tracer,
       BiFunction<String, ConsumerRecord, String> consumerSpanNameProvider,
       Collection<SpanDecorator> spanDecorators) {
     SpanContext parentContext = TracingKafkaUtils.extractSpanContext(record.headers(), tracer);


### PR DESCRIPTION
Changes the visibility for `buildAndFinishChildSpan` and `buildAndInjectSpan` to be public for all methods so that a custom list of SpanDecorators can be provided. This is necessary when customizing interceptors. An example would be custom tracing interceptors for use with kafka connect.

There are several ways to solve this, including adding support for SpanDecorators to the tracing interceptor classes (which has it's own complications because of how Interceptors are instantiated and configured). I could not think of a reason why just those function signatures would not be public, given that there are multiple variants that already are public.